### PR TITLE
Finished 1.2 except for pictures

### DIFF
--- a/app/controllers/representatives_controller.rb
+++ b/app/controllers/representatives_controller.rb
@@ -4,4 +4,8 @@ class RepresentativesController < ApplicationController
   def index
     @representatives = Representative.all
   end
+
+  def show
+    @representative = Representative.find(params[:id])
+  end
 end

--- a/app/models/representative.rb
+++ b/app/models/representative.rb
@@ -4,24 +4,29 @@ class Representative < ApplicationRecord
   has_many :news_items, dependent: :delete_all
 
   def self.civic_api_to_representative_params(rep_info)
-    reps = []
-
-    rep_info.officials.each_with_index do |official, index|
-      ocdid_temp = ''
-      title_temp = ''
-
-      rep_info.offices.each do |office|
-        if office.official_indices.include? index
-          title_temp = office.name
-          ocdid_temp = office.division_id
-        end
-      end
-
-      rep = Representative.create!({ name: official.name, ocdid: ocdid_temp,
-          title: title_temp })
-      reps.push(rep)
+    rep_info.officials.each_with_index.map do |official, index|
+      office_data = extract_office_data(rep_info, index)
+      address_data = format_address(official.address&.first)
+      rep = office_data.merge(address_data).merge({
+                                                    name:     official.name,
+                                                    party:    official.party,
+                                                    photoUrl: official.photo_url
+                                                  })
+      Representative.create!(rep)
     end
+  end
 
-    reps
+  def self.extract_office_data(rep_info, index)
+    office = rep_info.offices.find { |o| o.official_indices.include? index }
+    { ocdid: office&.division_id, title: office&.name }
+  end
+
+  def self.format_address(address)
+    {
+      street: [address&.line1, address&.line2, address&.line3].compact.join(' '),
+      city:   address&.city,
+      state:  address&.state,
+      zip:    address&.zip
+    }
   end
 end

--- a/app/views/news_items/index.html.haml
+++ b/app/views/news_items/index.html.haml
@@ -1,6 +1,8 @@
 .container-fluid.py-5
     .row
         .col-md-8.offset-md-2
+            %h1.text-center
+                = link_to @representative.name, representative_path(@representative), class: 'text-decoration-none'
             %h1.text-center Listing News Articles for #{@representative.name}
             .clearfix.my-4
                 .float-right

--- a/app/views/news_items/show.html.haml
+++ b/app/views/news_items/show.html.haml
@@ -15,8 +15,7 @@
                 %dl.row
                     %dt.col-sm-3.text-md-right Representative:
                     %dt.col-sm-9
-                        %a{ href: representative_path(@representative) }
-                            = @news_item.representative.name
+                        = link_to @news_item.representative.name, representative_path(@representative)
                 %dl.row
                     %dt.col-sm-3.text-md-right Time Added:
                     %dt.col-sm-9

--- a/app/views/representatives/search.html.haml
+++ b/app/views/representatives/search.html.haml
@@ -8,12 +8,15 @@
                         %tr
                             %th Name
                             %th Office
+                            %th Profile
                             %th Links
                     %tbody
                         - @representatives.each_with_index do |rep, _index|
                             %tr
-                                %td= rep.name
+                                %td= link_to rep.name, representative_path(rep)
                                 %td= rep.title
+                                %td
+                                    = link_to 'Profile', representative_path(rep), class: 'btn btn-secondary'
                                 %td
                                     = link_to representative_news_items_path(rep.id), class: 'btn btn-primary' do
                                         %i.fas.fa-newspaper

--- a/app/views/representatives/show.html.erb
+++ b/app/views/representatives/show.html.erb
@@ -1,0 +1,7 @@
+<div class = "container">
+  <h1><%= @representative.name %></h1>
+  <img src = "<%= @representative.photoUrl %>" alt="<%= @representative.name %>">
+  <p>Title: <%= @representative.title %></p>
+  <p>Party: <%= @representative.party %></p>
+  <p>Address: <%= @representative.street %>, <%= @representative.city %>, <%= @representative.state%>
+</div>

--- a/db/migrate/20231122051843_add_details_to_representatives.rb
+++ b/db/migrate/20231122051843_add_details_to_representatives.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddDetailsToRepresentatives < ActiveRecord::Migration[5.2]
+  def change
+    add_column :representatives, :street, :string
+    add_column :representatives, :city, :string
+    add_column :representatives, :state, :string
+    add_column :representatives, :zip, :string
+    add_column :representatives, :party, :string
+    add_column :representatives, :photo_url, :string
+  end
+end

--- a/db/migrate/20231122082349_rename_photo_url.rb
+++ b/db/migrate/20231122082349_rename_photo_url.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class RenamePhotoUrl < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :representatives, :photo_url, :string
+    add_column :representatives, :photoUrl, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_28_065604) do
+ActiveRecord::Schema.define(version: 2023_11_22_082349) do
 
   create_table "counties", force: :cascade do |t|
     t.string "name", null: false
@@ -49,6 +49,12 @@ ActiveRecord::Schema.define(version: 2020_07_28_065604) do
     t.datetime "updated_at", null: false
     t.string "ocdid"
     t.string "title"
+    t.string "street"
+    t.string "city"
+    t.string "state"
+    t.string "zip"
+    t.string "party"
+    t.string "photoUrl"
   end
 
   create_table "states", force: :cascade do |t|

--- a/features/representative_profile.feature
+++ b/features/representative_profile.feature
@@ -1,0 +1,9 @@
+Feature: Representative Profile
+  As a user
+  I want to view a representative's profile
+  So that I can learn more about them
+
+  Scenario: User views a representative's profile
+    Given a representative exists
+    When I visit the representative's profile page
+    Then I should see the representative's details

--- a/features/step_definitions/representative_steps.rb
+++ b/features/step_definitions/representative_steps.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-Given /a representative exists/  do
+Given /a representative exists/ do
   @representative = Representative.create!({
                                              name:     'Joe Biden',
                                              title:    'President of the United States',

--- a/features/step_definitions/representative_steps.rb
+++ b/features/step_definitions/representative_steps.rb
@@ -1,23 +1,23 @@
 # frozen_string_literal: true
 
-Given('a representative exists') do
+Given /a representative exists/  do
   @representative = Representative.create!({
-                                             name:     'John Smith',
-                                             title:    'Senator',
-                                             ocdid:    'test',
-                                             street:   '2 1st street',
-                                             city:     'Berkeley',
-                                             state:    'California',
+                                             name:     'Joe Biden',
+                                             title:    'President of the United States',
+                                             ocdid:    '445',
+                                             street:   '1600 Pennsylvania Avenue Northwest',
+                                             city:     'Washington',
+                                             state:    'DC',
                                              party:    'Democratic party',
-                                             photoUrl: 'test'
+                                             photoUrl: nil
                                            })
 end
 
-When("I visit the representative's profile page") do
+When /I visit the representative's profile page/ do
   visit representative_path(@representative)
 end
 
-Then("I should see the representative's details") do
+Then /I should see the representative's details/ do
   expect(page).to have_text(@representative.name)
   expect(page).to have_text(@representative.street)
   expect(page).to have_text(@representative.city)

--- a/features/step_definitions/representative_steps.rb
+++ b/features/step_definitions/representative_steps.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+Given('a representative exists') do
+  @representative = Representative.create!({
+                                             name:     'John Smith',
+                                             title:    'Senator',
+                                             ocdid:    'test',
+                                             street:   '2 1st street',
+                                             city:     'Berkeley',
+                                             state:    'California',
+                                             party:    'Democratic party',
+                                             photoUrl: 'test'
+                                           })
+end
+
+When("I visit the representative's profile page") do
+  visit representative_path(@representative)
+end
+
+Then("I should see the representative's details") do
+  expect(page).to have_text(@representative.name)
+  expect(page).to have_text(@representative.street)
+  expect(page).to have_text(@representative.city)
+  expect(page).to have_text(@representative.state)
+  expect(page).to have_text(@representative.party)
+end

--- a/spec/models/representative_spec.rb
+++ b/spec/models/representative_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'spec_helper'
+
+RSpec.describe Representative, type: :model do
+  before do
+    @rep = described_class.new(
+      name:     'John Doe',
+      ocdid:    'example',
+      title:    'Senator',
+      street:   '1 2nd street',
+      city:     'Berkeley',
+      state:    'California',
+      party:    'Democratic party',
+      photoUrl: 'test'
+    )
+  end
+
+  it 'is valid with valid attributes' do
+    expect(@rep).to be_valid
+  end
+end


### PR DESCRIPTION
The representative profile page is completed and functional with one exception. For some reason, images aren't correctly loading. The API (https://developers.google.com/civic-information/docs/using_api#representativeinfobyaddress-response:) shows that there should be a photoUrl returned in officials but when using official.photoUrl I get a method not found error. For some reason official.photo_url doesn't error but still doesn't correctly display the photo.